### PR TITLE
fix: make promises call `scope.end()` in `measureFn`

### DIFF
--- a/packages/rian/src/utils.ts
+++ b/packages/rian/src/utils.ts
@@ -7,7 +7,7 @@ export const measureFn = (scope: Scope, fn: any, ...args: any[]) => {
 		var r = fn(...args, scope),
 			is_promise = r instanceof Promise;
 
-		if (is_promise && PROMISES.has(scope))
+		if (is_promise && !PROMISES.has(scope))
 			ADD_PROMISE(
 				scope,
 				r

--- a/packages/rian/test/measure.spec.ts
+++ b/packages/rian/test/measure.spec.ts
@@ -1,4 +1,5 @@
 import { spy } from 'nanospy';
+import { PROMISES } from 'rian';
 import { suite, test } from 'uvu';
 import * as assert from 'uvu/assert';
 
@@ -45,6 +46,28 @@ test('should retain `this` context', async () => {
 
 	const result = measure(scope as any, 'test', fn.run.bind(fn));
 	assert.equal(result, 'foobar');
+});
+
+test('should call .end()', async () => {
+	const scope = mock_scope();
+	scope.fork = () => scope; // keep the current scope so we can assert it
+
+	assert.equal(
+		measure(scope as any, 'test', () => 'hello'),
+		'hello',
+	);
+	assert.equal(scope.end.callCount, 1);
+
+	assert.equal(
+		await measure(
+			scope as any,
+			'test',
+			() => new Promise((res) => setTimeout(() => res('hello'))),
+		),
+		'hello',
+	);
+	await Promise.all(PROMISES.get(scope as any) ?? []);
+	assert.equal(scope.end.callCount, 2);
 });
 
 test.run();


### PR DESCRIPTION
Hi @maraisr, I've found a little issue where `.end()` is not being called by `measureFn` when we're measuring promises. It makes spans missing the end time and hence duration.