### PR TITLE
feat: no longer track promises in a global variable

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -114,6 +114,11 @@ export interface Scope {
 	 * timestamp nulled out — when the tracer ends.
 	 */
 	end(): void;
+
+	/**
+	 * @internal
+	 */
+	__add_promise: (p: Promise<any>) => void;
 }
 
 export interface Tracer extends Omit<Scope, 'end'> {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -114,11 +114,6 @@ export interface Scope {
 	 * timestamp nulled out — when the tracer ends.
 	 */
 	end(): void;
-
-	/**
-	 * @internal
-	 */
-	__add_promise: (p: Promise<any>) => void;
 }
 
 export interface Tracer extends Omit<Scope, 'end'> {
@@ -175,7 +170,7 @@ export interface Options {
 	 * If the id is malformed, the {@link create} method will throw an exception. If no root is
 	 * provided then one will be created obeying the {@link Options.sampler|sampling} rules.
 	 */
-	traceparent?: string;
+	traceparent?: string | null;
 }
 
 export const create: (name: string, options: Options) => Tracer;
@@ -186,9 +181,3 @@ export const create: (name: string, options: Options) => Tracer;
 export interface CallableScope extends Scope {
 	(cb: (scope: Omit<Scope, 'end'>) => void): ReturnType<typeof cb>;
 }
-
-/** @internal */
-export const PROMISES: WeakMap<Scope, Promise<any>[]>;
-
-/** @internal */
-export const ADD_PROMISE: (scope: Scope, promise: Promise<any>) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export const create = (name: string, options: Options): Tracer => {
 			if (span_obj.end == null) span_obj.end = Date.now();
 		};
 
+		// @ts-expect-error
 		$.__add_promise = promises.add.bind(promises);
 
 		return $;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,10 @@
-import type { Traceparent } from 'tctx';
-import * as tctx from 'tctx';
+import type { CallableScope, Options, Sampler, Span, Tracer } from 'rian';
 import { measureFn } from 'rian/utils';
 
-declare const RIAN_VERSION: string;
+import type { Traceparent } from 'tctx';
+import * as tctx from 'tctx';
 
-import type {
-	Scope,
-	Sampler,
-	Span,
-	Options,
-	Tracer,
-	CallableScope,
-} from 'rian';
+declare const RIAN_VERSION: string;
 
 /**
  * The default sampler;

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export const create = (name: string, options: Options): Tracer => {
 			if (span_obj.end == null) span_obj.end = Date.now();
 		};
 
-		$.__add_promise = (p) => void promises.add(p);
+		$.__add_promise = promises.add.bind(promises);
 
 		return $;
 	};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,8 @@ export const measureFn = (scope: Scope, fn: any, ...args: any[]) => {
 		var r = fn(...args, scope),
 			is_promise = r instanceof Promise;
 
-		if (is_promise)
+		if (is_promise) {
+			// @ts-expect-error
 			scope.__add_promise(
 				r
 					.catch(
@@ -17,6 +18,7 @@ export const measureFn = (scope: Scope, fn: any, ...args: any[]) => {
 					)
 					.finally(() => scope.end()),
 			);
+		}
 
 		return r;
 	} catch (e) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,15 +6,17 @@ export const measureFn = (scope: Scope, fn: any, ...args: any[]) => {
 		var r = fn(...args, scope),
 			is_promise = r instanceof Promise;
 
-		if (is_promise) {
-			scope.__add_promise(r);
-			r.catch(
-				(e: Error): void =>
-					void scope.set_context({
-						error: e,
-					}),
-			).finally(() => scope.end());
-		}
+		if (is_promise)
+			scope.__add_promise(
+				r
+					.catch(
+						(e: Error): void =>
+							void scope.set_context({
+								error: e,
+							}),
+					)
+					.finally(() => scope.end()),
+			);
 
 		return r;
 	} catch (e) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,24 +1,20 @@
 import type { Scope } from 'rian';
 import type { MeasureFn, RealMeasureFnParams } from 'rian/utils';
-import { ADD_PROMISE, PROMISES } from 'rian';
 
 export const measureFn = (scope: Scope, fn: any, ...args: any[]) => {
 	try {
 		var r = fn(...args, scope),
 			is_promise = r instanceof Promise;
 
-		if (is_promise && !PROMISES.has(scope))
-			ADD_PROMISE(
-				scope,
-				r
-					.catch(
-						(e: Error): void =>
-							void scope.set_context({
-								error: e,
-							}),
-					)
-					.finally(() => scope.end()),
-			);
+		if (is_promise) {
+			scope.__add_promise(r);
+			r.catch(
+				(e: Error): void =>
+					void scope.set_context({
+						error: e,
+					}),
+			).finally(() => scope.end());
+		}
 
 		return r;
 	} catch (e) {

--- a/test/measure.spec.ts
+++ b/test/measure.spec.ts
@@ -1,5 +1,4 @@
 import { spy } from 'nanospy';
-import { PROMISES } from 'rian';
 import { suite, test } from 'uvu';
 import * as assert from 'uvu/assert';
 
@@ -9,6 +8,7 @@ const mock_scope = () => ({
 	fork: mock_scope,
 	end: spy(),
 	set_context: spy(),
+	__add_promise: spy(),
 });
 
 test('exports', () => {
@@ -66,7 +66,9 @@ test('should call .end()', async () => {
 		),
 		'hello',
 	);
-	await Promise.all(PROMISES.get(scope as any) ?? []);
+
+	assert.equal(scope.__add_promise.callCount, 1);
+	await scope.__add_promise.calls[0];
 	assert.equal(scope.end.callCount, 2);
 });
 

--- a/test/rian.spec.ts
+++ b/test/rian.spec.ts
@@ -102,6 +102,21 @@ test('has start and end times', async () => {
 	assert.equal(arr[1].end, 2);
 });
 
+test('promise returns', async () => {
+	let spans: ReadonlySet<Span>;
+	const tracer = rian.create('test', {
+		exporter: (x) => (spans = x),
+	});
+
+	const prom = new Promise((resolve) => setTimeout(resolve, 0));
+
+	await tracer.fork('test')(() => prom);
+
+	await tracer.end();
+
+	assert.equal(spans!.size, 2);
+});
+
 test.run();
 
 const fn = suite('fn mode');

--- a/test/rian.spec.ts
+++ b/test/rian.spec.ts
@@ -110,7 +110,7 @@ test('promise returns', async () => {
 
 	const prom = new Promise((resolve) => setTimeout(resolve, 0));
 
-	// Don't await here so we can assert the __add__promise worked 
+	// Don't await here so we can assert the __add__promise worked
 	tracer.fork('test')(() => prom);
 
 	await tracer.end();

--- a/test/rian.spec.ts
+++ b/test/rian.spec.ts
@@ -110,7 +110,8 @@ test('promise returns', async () => {
 
 	const prom = new Promise((resolve) => setTimeout(resolve, 0));
 
-	await tracer.fork('test')(() => prom);
+	// Don't await here so we can assert the __add__promise worked 
+	tracer.fork('test')(() => prom);
 
 	await tracer.end();
 


### PR DESCRIPTION
Lets track the promises we require before we end our tracer via the scope.

fixes: #2