### PR TITLE
Adding a parameter for an altered system clock state

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -173,7 +173,9 @@ export interface Options {
 	traceparent?: string | null;
 }
 
-export const create: (name: string, options: Options, start_offset?: number) => Tracer;
+export type ClockLike = { now(): number };
+
+export const create: (name: string, options: Options, clock?:ClockLike) => Tracer;
 
 // ==> internals
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -173,7 +173,7 @@ export interface Options {
 	traceparent?: string | null;
 }
 
-export const create: (name: string, options: Options) => Tracer;
+export const create: (name: string, options: Options, start_offset?: number) => Tracer;
 
 // ==> internals
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ const sdk_object = {
 	'telemetry.sdk.version': RIAN_VERSION,
 };
 
-export const create = (name: string, options: Options): Tracer => {
+export const create = (name: string, options: Options, start_offset = 0): Tracer => {
 	const spans: Set<Span> = new Set();
 	const promises: Set<Promise<any>> = new Set();
 
@@ -45,7 +45,7 @@ export const create = (name: string, options: Options): Tracer => {
 		const span_obj: Span = {
 			id,
 			parent,
-			start: Date.now(),
+			start: Date.now() + start_offset,
 			name,
 			events: [],
 			context: {},

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { CallableScope, Options, Sampler, Span, Tracer } from 'rian';
+import type { CallableScope, Options, Sampler, Span, Tracer, ClockLike } from 'rian';
 import { measureFn } from 'rian/utils';
 
 import type { Traceparent } from 'tctx';
@@ -26,7 +26,8 @@ const sdk_object = {
 	'telemetry.sdk.version': RIAN_VERSION,
 };
 
-export const create = (name: string, options: Options, start_offset = 0): Tracer => {
+
+export const create = (name: string, options: Options, clock: ClockLike = Date): Tracer => {
 	const spans: Set<Span> = new Set();
 	const promises: Set<Promise<any>> = new Set();
 
@@ -45,7 +46,7 @@ export const create = (name: string, options: Options, start_offset = 0): Tracer
 		const span_obj: Span = {
 			id,
 			parent,
-			start: Date.now() + start_offset,
+			start: clock.now(),
 			name,
 			events: [],
 			context: {},
@@ -66,12 +67,12 @@ export const create = (name: string, options: Options, start_offset = 0): Tracer
 		$.add_event = (name, attributes) => {
 			span_obj.events.push({
 				name,
-				timestamp: Date.now(),
+				timestamp: clock.now(),
 				attributes: attributes || {},
 			});
 		};
 		$.end = () => {
-			if (span_obj.end == null) span_obj.end = Date.now();
+			if (span_obj.end == null) span_obj.end = clock.now();
 		};
 
 		// @ts-expect-error

--- a/test/rian.spec.ts
+++ b/test/rian.spec.ts
@@ -77,14 +77,14 @@ test('context', async () => {
 	});
 });
 
-test('has start and end times', async () => {
+test('has offset start and end times', async () => {
 	let called = -1;
 	spyOn(Date, 'now', () => ++called);
 
 	let spans: ReadonlySet<Span>;
 	const tracer = rian.create('test', {
 		exporter: (x) => (spans = x),
-	});
+	}, 1);
 
 	tracer.fork('test')(spy());
 
@@ -96,9 +96,9 @@ test('has start and end times', async () => {
 	const arr = Array.from(spans);
 
 	// 2 spans, 2 calls per span
-	assert.equal(arr[0].start, 0);
+	assert.equal(arr[0].start, 1);
 	assert.equal(arr[0].end, 3);
-	assert.equal(arr[1].start, 1);
+	assert.equal(arr[1].start, 2);
 	assert.equal(arr[1].end, 2);
 });
 

--- a/test/rian.spec.ts
+++ b/test/rian.spec.ts
@@ -84,7 +84,7 @@ test('has offset start and end times', async () => {
 	let spans: ReadonlySet<Span>;
 	const tracer = rian.create('test', {
 		exporter: (x) => (spans = x),
-	}, 1);
+	}, {now: () => Date.now() + 5});
 
 	tracer.fork('test')(spy());
 
@@ -96,10 +96,10 @@ test('has offset start and end times', async () => {
 	const arr = Array.from(spans);
 
 	// 2 spans, 2 calls per span
-	assert.equal(arr[0].start, 1);
-	assert.equal(arr[0].end, 3);
-	assert.equal(arr[1].start, 2);
-	assert.equal(arr[1].end, 2);
+	assert.equal(arr[0].start, 5);
+	assert.equal(arr[0].end, 8);
+	assert.equal(arr[1].start, 6);
+	assert.equal(arr[1].end, 7);
 });
 
 test('promise returns', async () => {


### PR DESCRIPTION
<!-- what are you solving here -->

For certain workers Date.now() won't reflect time correctly, since processor time is not visible. In these cases manual offset for the starting point can be required. 